### PR TITLE
remove unnecessary babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["next/babel", "env"],
+  "presets": ["next/babel"],
   "plugins": ["glamorous-displayname"]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "babel-jest": "^20.0.3",
     "babel-plugin-glamorous-displayname": "^2.1.0",
-    "babel-preset-env": "^1.6.0",
     "enzyme": "^2.9.1",
     "enzyme-to-json": "^1.5.1",
     "jest": "^20.0.4",


### PR DESCRIPTION
Before this change, the tests and build work fine. This is the output I'm getting with tests with this change:

```
~/Developer/glamorous-with-next (pr/fix-config)
😇  $ npm run test --silent
 FAIL  components/__tests__/toggle-button.js
  ● Test suite failed to run

    /Users/kdodds/Developer/glamorous-with-next/components/__tests__/toggle-button.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){var _jsxFileName = '/Users/kdodds/Developer/glamorous-with-next/components/__tests__/toggle-button.js';import React from 'react';
                                                                                                                                                                                                    ^^^^^^
    
    SyntaxError: Unexpected token import
      
      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/ScriptTransformer.js:289:17)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.908s
Ran all test suites.
```

The build works fine.

Anyone have any ideas? I want the "add the glamorous babel plugin" portion of my course to add only the minimal required stuff and I'm pretty sure that the `next/babel` preset should be including the `env` preset already 🤔 